### PR TITLE
[docker] Use Latest Conda

### DIFF
--- a/docker/base-deps/Dockerfile
+++ b/docker/base-deps/Dockerfile
@@ -16,24 +16,25 @@ RUN apt-get update \
         screen \
         rsync \
     && apt-get clean \
-    && echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh \
     && wget \
-        --quiet "https://repo.anaconda.com/miniconda/Miniconda3-4.7.12.1-Linux-x86_64.sh" \
-        -O /tmp/anaconda.sh \
-    && /bin/bash /tmp/anaconda.sh -b -p /opt/conda \
-    && rm /tmp/anaconda.sh \
-    && /opt/conda/bin/conda install -y \
+        --quiet "https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh" \
+        -O /tmp/miniconda.sh \
+    && /bin/bash miniconda.sh -b -u -p $HOME/anaconda3 \
+    && $HOME/anaconda3/bin/conda init \ 
+    && echo 'export PATH=$HOME/anaconda3/bin:$PATH' > /etc/profile.d/conda.sh \
+    && rm /tmp/miniconda.sh \
+    && $HOME/anaconda3/bin/conda install -y \
         libgcc python=3.6.9 \
-    && /opt/conda/bin/conda clean -y --all \
-    && /opt/conda/bin/pip install --no-cache-dir \
+    && $HOME/anaconda3/bin/conda clean -y --all \
+    && $HOME/anaconda3/bin/pip install --no-cache-dir \
         flatbuffers \
         cython==0.29.0 \
         numpy==1.15.4 \
     # To avoid the following error on Jenkins:
     # AttributeError: 'numpy.ufunc' object has no attribute '__module__'
-    && /opt/conda/bin/pip uninstall -y dask
+    && $HOME/anaconda3/bin/pip uninstall -y dask
 
-ENV PATH "/opt/conda/bin:$PATH"
+ENV PATH "$HOME/anaconda3/bin:$PATH"
 
 # OLD IS 
 # ray-project/base-deps                latest              50a2d9de82fa        30 seconds ago      961MB


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?
Using the latest miniconda defaults to `Python 3.7`!

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
